### PR TITLE
Removing MySQL from the Prerequisite options as only Postgres is comp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ container.
 ## Prerequisites Details
 
 * Kubernetes 1.6+
-* A database service installed and configured (MySQL, PostgreSQL)
+* A database service installed and configured (PostgreSQL)
 
 ## Chart Details
 


### PR DESCRIPTION
Removing MySQL from the Prerequisite options as only Postgres is compatible.